### PR TITLE
Update docker-image-management.yaml to include caching

### DIFF
--- a/.github/workflows/docker-image-management.yaml
+++ b/.github/workflows/docker-image-management.yaml
@@ -88,6 +88,8 @@ jobs:
           context: .
           file: load-generator/Dockerfile.arcdemo
           platforms: linux/amd64,linux/arm64/v8
+          cache-from: type=gha
+          cache-to: type=gha
           push: true
           tags: | # Use ${{ secrets.DOCKER_USERNAME }} instead of robertslee?
             robertslee/arcdemo:${{ inputs.IMAGE_TAG }}


### PR DESCRIPTION
The build-push action for docker in github actions also has a cache-from and cache-to option, which can be set to GitHub Actions (gha) and it will cache the layers (default set to min, only the layers used in the final image) using github's provided cache (https://github.com/actions/cache). The allowed cache for a repository is 10gb, so I'm not certain if we're under that or not, we might not be. If you go over, it shouldn't charge, just start ejecting the least recently used thing in the cache (see the provided link). Next step, if there's still enough space in the cache, would be to cache the dependencies of the replicant cli and row verificator.