### PR TITLE
Added source label to docker image

### DIFF
--- a/.github/workflows/docker-image-management.yaml
+++ b/.github/workflows/docker-image-management.yaml
@@ -95,3 +95,4 @@ jobs:
             robertslee/arcdemo:${{ inputs.IMAGE_TAG }}
             ghcr.io/arcionlabs/arcdemo:${{ inputs.IMAGE_TAG }}
           # Will ghcr allow authentication to something other than "arcionlabs/arcion-loadgen"?
+          labels: org.opencontainers.image.source=https://github.com/arcionlabs/arcion-loadgen


### PR DESCRIPTION
Added an image source tag to the build action (https://specs.opencontainers.org/image-spec/annotations/) which should connect it to the repository (see [here](https://docs.github.com/en/packages/learn-github-packages/connecting-a-repository-to-a-package#connecting-a-repository-to-a-container-image-using-the-command-line)), which should allow it to inherit the permissions of the repository (see [here](https://docs.github.com/en/packages/learn-github-packages/configuring-a-packages-access-control-and-visibility#about-inheritance-of-access-permissions-and-visibility)). If none of this works, might have to try some more stuff, or have someone log in to arcionlabs and set it [manually](https://docs.github.com/en/packages/learn-github-packages/configuring-a-packages-access-control-and-visibility#configuring-visibility-of-packages-for-your-personal-account), however I don't know if future uploads will merge with the previous one and remain public or not.