### PR TITLE
159 allow command line control in GitHub action run

### DIFF
--- a/.github/workflows/arcdemosh_test.yaml
+++ b/.github/workflows/arcdemosh_test.yaml
@@ -20,6 +20,11 @@ on:
         required: true
         default: 'artifact-data'
         type: string
+      COMMANDS:
+        description: 'Which command(s) to run with the source(s) and destination(s), formatted as a list'
+        required: true
+        default: '["arcdemo.sh -r 0 snapshot", "arcdemo.sh -r 0 real-time", "arcdemo.sh -r 0 full"]'
+        type: string
 
 jobs:
   run-demo:
@@ -57,7 +62,18 @@ jobs:
           sleep 40
           docker exec workloads mkdir -p /opt/stage/data
           echo "Made it to execution"
-          docker exec workloads arcdemo.sh snapshot ${{ matrix.src }} ${{ matrix.dest }}
+          IFS=$'\n'
+          for command in $(echo '${{ inputs.COMMANDS }}' | jq -r '.[]' ); do
+            set -- docker exec workloads
+            IFS=$' '
+            for param in $command; do
+              set -- "$@" $param
+            done
+            set -- "$@" ${{ matrix.src }} ${{ matrix.dest }}
+            "$@"
+            IFS=$'\n'
+          done
+          IFS=$' '
       - name: Extract files
         if: '!cancelled()'
         run: |

--- a/docs/tests/source-target-demo.md
+++ b/docs/tests/source-target-demo.md
@@ -26,7 +26,7 @@ The name of the bucket in storj to which the artifacts should be uploaded. Defau
 
 ### `COMMANDS`
 A list of the commands to be run on the source and target databases. Usually starts with arcdemo.sh,
-as we are running the demo on the databases. Defaults to `["arcdemo.sh -r 0 snapshot" , "arcdemo.sh -r 0 real-time", "arcdemo.sh -r 0 full" ]`
+as we are running the demo on the databases. Does not work with options that have a space or newline in them (e.g. `command "path/to something/file"` doesn't work but `command path/to-something/file` does). Defaults to `["arcdemo.sh -r 0 snapshot", "arcdemo.sh -r 0 real-time", "arcdemo.sh -r 0 full" ]`.
 
 ### Notes:
 > On a free plan, GitHub actions will only run at most [20 concurrent jobs](https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#usage-limits), and a job matrix can assign at most [256 jobs](https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#usage-limits). I have not tested running more than 20 because I don't want to go over the other limit of [2000 minutes per month](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#included-storage-and-minutes), although this may be different for a public repository. The rates don't seem too expensive if you go over this, however it could get expensive fast if you have a lot of jobs running at once.

--- a/docs/tests/source-target-demo.md
+++ b/docs/tests/source-target-demo.md
@@ -9,7 +9,7 @@ for your own records, as you can't see it again once you finish creating the acc
 
 # Running the Action
 
-The action is currently set to be run on `workflow_dispatch` and takes in three inputs: `SRC_DATABASES`, `DST_DATABASES`, and `BUCKET_NAME`.
+The action is currently set to be run on `workflow_dispatch` and takes in four inputs: `SRC_DATABASES`, `DST_DATABASES`, `BUCKET_NAME`, and `COMMANDS`.
 
 ### `SRC_DATABASES`
 A list of databases to be used as sources. This should be formatted as such: `["database_1", "database_2", "database_3"]`, where `database_#` is both the short name for the database and the name of the folder containing the docker compose file.
@@ -23,6 +23,10 @@ of the folder containing the docker compose file. Defaults to `["pg"]`.
 
 ### `BUCKET_NAME`
 The name of the bucket in storj to which the artifacts should be uploaded. Defaults to `artifact-data`.
+
+### `COMMANDS`
+A list of the commands to be run on the source and target databases. Usually starts with arcdemo.sh,
+as we are running the demo on the databases. Defaults to `["arcdemo.sh -r 0 snapshot" , "arcdemo.sh -r 0 real-time", "arcdemo.sh -r 0 full" ]`
 
 ### Notes:
 > On a free plan, GitHub actions will only run at most [20 concurrent jobs](https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#usage-limits), and a job matrix can assign at most [256 jobs](https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#usage-limits). I have not tested running more than 20 because I don't want to go over the other limit of [2000 minutes per month](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#included-storage-and-minutes), although this may be different for a public repository. The rates don't seem too expensive if you go over this, however it could get expensive fast if you have a lot of jobs running at once.


### PR DESCRIPTION
You should be able to write a list of commands to pass to the container and have the container run them. Allows for running multiple option configurations for each. Note that bash does not like you to run commands from variables, so there is some spaghetti, and you can't put spaces in a single option, even if they're enclosed in quotes (like "path/to a/file"), which is included in the documentation.