### PR TITLE
Mostly working version of rclone based artifact upload

### DIFF
--- a/.github/workflows/arcdemosh_test.yaml
+++ b/.github/workflows/arcdemosh_test.yaml
@@ -15,15 +15,27 @@ on:
         required: true
         default: '["pg"]'
         type: string
-      BUCKET_NAME:
-        description: 'Name of the storj bucket to upload to'
-        required: true
-        default: 'artifact-data'
-        type: string
       COMMANDS:
         description: 'Which command(s) to run with the source(s) and destination(s), formatted as a list'
         required: true
         default: '["arcdemo.sh -r 0 snapshot", "arcdemo.sh -r 0 real-time", "arcdemo.sh -r 0 full"]'
+        type: string
+      RCLONE_CONFIG:
+        descriptions: 'rclone config command to run. Necessary parameters will vary based on connection. See https://rclone.org/commands/rclone_config_create/'
+        required: true
+        default: 'rclone config create myremote storj access_grant=*ACCESS GRANT HERE*'
+      REMOTE_NAME:
+        description: 'What is the name of the remote access you created in RCLONE_CONFIG?'
+        required: true
+        default: 'myremote'
+      MY_SECRET_NAME:
+        description: 'What is the name of the secret that you want to be redacted from the log file?'
+        required: false
+        default: 'UPLINK_ACC'
+      BUCKET_NAME:
+        description: 'Name of the bucket to upload to'
+        required: true
+        default: 'artifact-data'
         type: string
 
 jobs:
@@ -36,6 +48,8 @@ jobs:
       fail-fast: false
     timeout-minutes: 30
     runs-on: ubuntu-latest
+    env:
+      MY_SECRET_VAR: ${{secrets[inputs.MY_SECRET_NAME]}}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -81,13 +95,9 @@ jobs:
           cd artifact_data
           for f in $(docker exec workloads ls /opt/stage/data | grep -v README.md); do docker exec workloads tar Ccf $(dirname /opt/stage/data/$f) - $(basename /opt/stage/data/$f) | tar Cxf . -; echo $f; done
           cd ..
-      - name: Storj upload
+      - name: Upload to central storage
         if: '!cancelled()'
         run: |
-          curl -L https://github.com/storj/storj/releases/latest/download/uplink_linux_amd64.zip -o uplink_linux_amd64.zip
-          unzip -o uplink_linux_amd64.zip
-          sudo install uplink /usr/local/bin/uplink
-          echo "${{ secrets.UPLINK_ACC }}" > access_grant.txt
-          uplink access import main access_grant.txt
-          cd artifact_data
-          for f in *; do tar -cf $f.tar $f; uplink cp $f.tar sj://${{ inputs.BUCKET_NAME }}; done
+          sudo -v ; curl https://rclone.org/install.sh | sudo bash
+          ${{ inputs.RCLONE_CONFIG }}
+          rclone copy artifact_data ${{ inputs.REMOTE_NAME }}:${{ inputs.BUCKET_NAME }}

--- a/docs/tests/source-target-demo.md
+++ b/docs/tests/source-target-demo.md
@@ -1,5 +1,10 @@
 # Initial Set-Up
+Set up your artifact repository however you want, and then adjust the `RCLONE_CONFIG` and `BUCKET_NAME` to correctly connect to it.
+`MY_SECRET_NAME` is used as a workaround to scrub a private piece of information passed into the command `RCLONE_CONFIG`. NOTE: I do not know how reliable
+this is in getting everything out of the log file. Be VERY careful. A more robust approach would see you editing the workflow itself to have a mostly hard coded rclone command where you pull an access key or password from secrets, rather than pasting it wholesale into the inputs and trusting that introducing a secret with the same access key or password will then scrub that from the log file's records of the inputs.
+However, for the sake of allowing you to connect to almost any bucket/data hosting tool by just changing the `RCLONE_CONFIG` command, I've left this in. I strongly recommend changing it as soon you are settled on a provider. Please do not accidentally leak your password or access grant.
 
+## If using storj
 First, as this uses storj.io as the artifact repository, you need to have an account, bucket, and access grant set up as
 instructed in [storj docs](https://docs.storj.io/dcs/getting-started/quickstart-uplink-cli/uploading-your-first-object/create-first-access-grant). 
 
@@ -9,7 +14,8 @@ for your own records, as you can't see it again once you finish creating the acc
 
 # Running the Action
 
-The action is currently set to be run on `workflow_dispatch` and takes in four inputs: `SRC_DATABASES`, `DST_DATABASES`, `BUCKET_NAME`, and `COMMANDS`.
+The action is currently set to be run on `workflow_dispatch` and takes in seven inputs: `SRC_DATABASES`, `DST_DATABASES`, `COMMANDS`,
+`RCLONE_CONFIG`, `REMOTE_NAME`, `BUCKET_NAME`, and `MY_SECRET_NAME`.
 
 ### `SRC_DATABASES`
 A list of databases to be used as sources. This should be formatted as such: `["database_1", "database_2", "database_3"]`, where `database_#` is both the short name for the database and the name of the folder containing the docker compose file.
@@ -21,12 +27,25 @@ all of the database combinations you would like to test. This should be formatte
 `["database_1", "database_2", "database_3"]`, where `database_#` is both the short name for the database and the name 
 of the folder containing the docker compose file. Defaults to `["pg"]`.
 
-### `BUCKET_NAME`
-The name of the bucket in storj to which the artifacts should be uploaded. Defaults to `artifact-data`.
 
 ### `COMMANDS`
 A list of the commands to be run on the source and target databases. Usually starts with arcdemo.sh,
 as we are running the demo on the databases. Does not work with options that have a space or newline in them (e.g. `command "path/to something/file"` doesn't work but `command path/to-something/file` does). Defaults to `["arcdemo.sh -r 0 snapshot", "arcdemo.sh -r 0 real-time", "arcdemo.sh -r 0 full" ]`.
+
+### `RCLONE_CONFIG`
+The rclone config command to run in order to set up your access. See [this](https://rclone.org/commands/rclone_config_create/) link
+for more info on what the `rclone config create` command does. Different storage providers need different details supplied, hence why the whole command is an input. Defaults to `rclone config create myremote storj access_grant=*ACCESS GRANT HERE*`.
+
+### `REMOTE_NAME`
+The name of the remote access which rclone uses. It should match the name of the access created by `RCLONE_CONFIG`. Defaults to `myremote`.
+
+### `BUCKET_NAME`
+The name of the bucket to which the artifacts should be uploaded. Defaults to `artifact-data`.
+
+### `MY_SECRET_NAME`
+NOTE: This is the log scrubbing workaround of having to type out a private piece of info into the `RCLONE_CONFIG` command. I do not know how reliable it is.
+
+The name of the github secret which contains a private piece of information you might be passing via the command line to `RCLONE_CONFIG`. For example, if you're passing a password in `RCLONE_CONFIG` like `password=P@55w0rd123`, you should create a github secret called `RCLONE_ACC_PASS` which contains `P@55w0rd123` and this input should be `RCLONE_ACC_PASS`, *not* the contents of the secret. Then, this secret can be introduced to the action and *should* be scrubbed from the log. Defaults to `UPLINK_ACC`.
 
 ### Notes:
 > On a free plan, GitHub actions will only run at most [20 concurrent jobs](https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#usage-limits), and a job matrix can assign at most [256 jobs](https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#usage-limits). I have not tested running more than 20 because I don't want to go over the other limit of [2000 minutes per month](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#included-storage-and-minutes), although this may be different for a public repository. The rates don't seem too expensive if you go over this, however it could get expensive fast if you have a lot of jobs running at once.


### PR DESCRIPTION
I changed around the github action to use rclone, however without being able to hardcode which storage provider to use, it is very finicky and very dangerous to be passing private information into the action input itself, as different storage providers will require different ways of providing private info. I've described the workaround in the documentation, however I'm sure there's a better one somewhere out there. Or, just pick a provider and settle on them, so you can use secrets directly and know what syntax your rclone config command will be. Closes #161 