### PR TITLE
160 allow retries in docker image build and build

### DIFF
--- a/.github/workflows/docker-image-management.yaml
+++ b/.github/workflows/docker-image-management.yaml
@@ -25,6 +25,16 @@ on:
         required: true
         default: 'main'
         type: string
+      RETRY:
+        description: 'In case the build-push action fails, should it retry?'
+        required: true
+        default: true
+        type: boolean
+      RETRY_AGAIN:
+        description: 'In case the build-push actions fails twice, should it retry?'
+        required: true
+        default: true
+        type: boolean
 
 jobs:
   push_to_registries:
@@ -82,6 +92,8 @@ jobs:
 
 
       - name: Build and push docker images
+        continue-on-error: true
+        id: build1
         uses: docker/build-push-action@v4
         # Github recommends pinning this to a specific SHA rather than @v4
         with:
@@ -91,8 +103,44 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha
           push: true
-          tags: | # Use ${{ secrets.DOCKER_USERNAME }} instead of robertslee?
+          tags: | 
             robertslee/arcdemo:${{ inputs.IMAGE_TAG }}
             ghcr.io/arcionlabs/arcdemo:${{ inputs.IMAGE_TAG }}
-          # Will ghcr allow authentication to something other than "arcionlabs/arcion-loadgen"?
+          labels: org.opencontainers.image.source=https://github.com/arcionlabs/arcion-loadgen
+
+          
+      - name: Retry One
+        continue-on-error: true
+        id: build2
+        if: ${{ steps.build1.outcome == 'failure' }} && ${{ inputs.RETRY == 'true'}}
+        uses: docker/build-push-action@v4
+        # Github recommends pinning this to a specific SHA rather than @v4
+        with:
+          context: .
+          file: load-generator/Dockerfile.arcdemo
+          platforms: linux/amd64,linux/arm64/v8
+          cache-from: type=gha
+          cache-to: type=gha
+          push: true
+          tags: | 
+            robertslee/arcdemo:${{ inputs.IMAGE_TAG }}
+            ghcr.io/arcionlabs/arcdemo:${{ inputs.IMAGE_TAG }}
+          labels: org.opencontainers.image.source=https://github.com/arcionlabs/arcion-loadgen
+
+      - name: Retry Two
+        continue-on-error: true
+        id: build3
+        if: ${{ steps.build2.outcome == 'failure' }} && ${{ inputs.RETRY_AGAIN == 'true'}}
+        uses: docker/build-push-action@v4
+        # Github recommends pinning this to a specific SHA rather than @v4
+        with:
+          context: .
+          file: load-generator/Dockerfile.arcdemo
+          platforms: linux/amd64,linux/arm64/v8
+          cache-from: type=gha
+          cache-to: type=gha
+          push: true
+          tags: | 
+            robertslee/arcdemo:${{ inputs.IMAGE_TAG }}
+            ghcr.io/arcionlabs/arcdemo:${{ inputs.IMAGE_TAG }}
           labels: org.opencontainers.image.source=https://github.com/arcionlabs/arcion-loadgen

--- a/docs/tests/docker-image-push-instructions.md
+++ b/docs/tests/docker-image-push-instructions.md
@@ -6,7 +6,7 @@ If you're looking to create a personal access token to use instead of your passw
 
 # Running the Action
 
-The action is currently set to be run on `workflow_dispatch` and takes in four inputs: `REPLICANT_CLI_URL`, `ROW_VERIFICATOR_URL`, `IMAGE_TAG`, and `CHECKOUT_CHOICE`.
+The action is currently set to be run on `workflow_dispatch` and takes in six inputs: `REPLICANT_CLI_URL`, `ROW_VERIFICATOR_URL`, `IMAGE_TAG`, `CHECKOUT_CHOICE`, `RETRY`, and `RETRY_AGAIN`.
 
 ### `REPLICANT_CLI_URL`
 The URL from which the replicant binary is downloaded. It defaults to https://arcion-releases.s3.us-west-1.amazonaws.com/general/replicant/replicant-cli-23.05.31.4.zip.
@@ -19,3 +19,7 @@ The tag to apply to the docker image that is built and pushed. Defaults to `late
 
 ### `CHECKOUT_CHOICE`
 The branch, tag, or SHA which is applied to the checkout action. Use this to choose which branch the image is built from, or use a commit hash to get even more specific. Defaults to `main`.
+
+## `RETRY` and `RETRY_AGAIN`
+These allow you to retry the build-push action once or twice, in case of network issues during the first attempt. Currently there is no
+delay before retrying, it may be a good idea to add a sleep for a minute or two.


### PR DESCRIPTION
Definitely not the best workaround to retry building the docker image, but I believe it should work. Wasn't able to make sure retries don't go when the first succeeds, as I can't have a successful push to *your* docker hub, keep an eye on that. Closes #160 